### PR TITLE
Remove references to other molecule role

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ cd /path/where/the/repo/will/be/cloned/to
 virtualenv --python python2 venv-molecule
 . venv-molecule/bin/activate
 pip install molecule testinfra ansible docker-py
-git clone git@github.com:johnduarte/molecule-ntp
-cd molecule-ntp
+git clone git@github.com:phongdly/molecule-validate-cinder-deploy
+cd molecule-validate-cinder-deploy
 molecule test
 ```
 
@@ -48,7 +48,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: molecule-ntp, x: 42 }
+         - { role: molecule-validate-cinder-deploy, x: 42 }
 
 Generate Molecule Config from Ansible Dynamic Inventory
 -------------------------------------------------------
@@ -65,7 +65,7 @@ cd /opt/openstack-ansible/playbooks/inventory
 Now you can generate a `molecule.yml` config file using the `moleculerize.py` script:
 
 ```
-cd /path/to/molecule-ntp
+cd /path/to/molecule-validate-cinder-deploy
 ./moleculerize.py /path/to/dynaic_inventory.json
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,2 @@
 ---
-# defaults file for molecule-ntp
-ntp_timezone: America/Los_Angeles
-ntp_servers:
-    - 0.us.pool.ntp.org
-    - 1.us.pool.ntp.org
-    - 2.us.pool.ntp.org
-    - 3.us.pool.ntp.org
+# defaults file for molecule-validate-cinder-deploy

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: molecule-ntp
+    - role: molecule-validate-cinder-deploy

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,5 @@
 ---
 - name: Converge
-  hosts: all
+  hosts: aio1
   roles:
     - role: molecule-validate-cinder-deploy

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,7 @@ import re
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('aio1')
 
 def test_cinder_service(host):
     cmd = "sudo bash -c \"source /root/openrc; cinder service-list\""

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# vars file for molecule-ntp
+# vars file for molecule-validate-cinder-deploy


### PR DESCRIPTION
This commit scrubs for references to the `molecule-ntp` role that were
accidentally added as part of the merge at SHA
ff2d504a24a9ba278faf272542bd6897daa54c58 and replaces them with the
correct role name.